### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/c7de2a56-79d3-4776-89a7-3b0c1e145c73/828150ed-cd48-4770-93b8-66e4c025af65/_apis/work/boardbadge/16f08785-912d-4b61-9359-fa4b8e067fcd)](https://dev.azure.com/aiw-devops/c7de2a56-79d3-4776-89a7-3b0c1e145c73/_boards/board/t/828150ed-cd48-4770-93b8-66e4c025af65/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1212](https://dev.azure.com/aiw-devops/c7de2a56-79d3-4776-89a7-3b0c1e145c73/_workitems/edit/1212). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.